### PR TITLE
cross arch builds, upstream debian and yt/pipes fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian
 
 MAINTAINER Werner Beroux <werner@beroux.com>
 
@@ -32,13 +32,12 @@ RUN apt-get update \
         vlc \
         watch \
         xaos \
-
-    && echo "Install lolcat and youtube-dl" \
-    && echo "deb http://http.us.debian.org/debian sid main non-free contrib" >> /etc/apt/sources.list \
-    && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         lolcat \
-        youtube-dl \
+        ffmpeg \
+
+    && echo "Install youtube-dl" \
+    && curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/bin/youtube-dl \
+    && chmod 755 /usr/bin/youtube-dl \
 
     && echo "Install asciiquarium" \
     && cpan -i Term::Animation \
@@ -53,7 +52,7 @@ RUN apt-get update \
     && chmod +x /usr/local/bin/falling-hearts \
 
     && echo "Install pipes" \
-    && curl -L https://gist.githubusercontent.com/livibetter/4689307/raw/949e43fe2962c2c97c8b1d974ff93dd053d9bd37/pipes.sh -o /usr/local/bin/pipes \
+    && curl -L https://raw.githubusercontent.com/pipeseroni/pipes.sh/refs/heads/master/pipes.sh -o /usr/local/bin/pipes \
     && chmod +x /usr/local/bin/pipes \
 
     && echo "Clean-up" \

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Setup buildx environment
+docker buildx create --name build_cross --driver-opt env.BUILDKIT_STEP_LOG_MAX_SIZE=10000000 --driver-opt env.BUILDKIT_STEP_LOG_MAX_SPEED=10000000 || true
+docker buildx use build_cross
+
+# Build and push
+docker buildx build --platform linux/386,linux/amd64,linux/arm64/v8,linux/arm/v6,linux/arm/v7,linux/ppc64le,linux/s390x -t wernight/funbox:latest . --push
+
+# Update local image
+docker pull wernight/funbox:latest


### PR DESCRIPTION
Hi @wernight,

Hope you're well, a blast from the past on this one! Whilst this is now an old project at close to 10 years, its one of my favourites for introducing people to containers and Docker! Thank you so much.

I've noticed recently, people experiencing problems when attempting to use this on Apple Silicon with the differences between the current amd64 image and arm/v8 needed for the newer Apple Silicon. In the past, it worked well, albeit with a warning and emulation but on more recent versions, it's been problematic.

I've been able to get this working by cross building for linux/386, amd64, arm64/v[6,7,8], ppc64le and s390x 😊

My mirror works as expected (spurin/funbox) however, ideally this is best served from your original image of wernight/funbox.

This PR has the changes I used to get this working and cross built. In summary:

- Image changed from debian:jessie to debian
- No need for the sid repository anymore, we can just install lolcat direct
- Switched youtube-dl to yt-dlp and added ffmpeg
- Added a cross compile build script as build.sh

The examples in the readme all work as expected including the YT one.

If you were happy to merge this, you should be able to run the build.sh from a modern version of Docker (I'm using Docker Desktop on Mac) to compile all of the variations and push an updated version image.

Hope this helps and great work on achieving 10 years with this awesome project!

Many Thanks


James